### PR TITLE
feat(capture): check if camera is available before trying to capture

### DIFF
--- a/lib/constant.dart
+++ b/lib/constant.dart
@@ -1,5 +1,7 @@
+import 'dart:io';
+
 import 'package:flutter/material.dart';
 
 const MaterialColor DEFAULT_COLOR = Colors.indigo;
-const String API_HOSTNAME = '10.0.2.2:5000';
+String API_HOSTNAME = Platform.isAndroid ? '10.0.2.2:5000' : '0.0.0.0:5000';
 const bool API_IS_HTTPS = false;

--- a/lib/page/capture_page.dart
+++ b/lib/page/capture_page.dart
@@ -24,10 +24,13 @@ class _CapturePageState extends State<CapturePage> {
   @override
   void initState() {
     super.initState();
-    initCamera(widget.cameras![0]);
+
+    if (widget.cameras?.isNotEmpty ?? false) {
+      initCamera(widget.cameras![0]);
+    }
   }
 
-  void goToCollectionCreationPage(){
+  void goToCollectionCreationPage() {
     context.push(Routes.newSequenceSend, extra: _imgListCaptured);
   }
 
@@ -43,10 +46,12 @@ class _CapturePageState extends State<CapturePage> {
     }
     try {
       if (await PermissionHelper.isPermissionGranted()) {
-        await Future.wait([
-          getPictureFromCamera(),
-          Geolocator.getCurrentPosition()
-        ]).then((value) async {
+        await Future.wait(
+          [
+            getPictureFromCamera(),
+            Geolocator.getCurrentPosition(),
+          ],
+        ).then((value) async {
           final XFile rawImage = value[0] as XFile;
           final Position currentLocation = value[1] as Position;
           await addExifTags(rawImage, currentLocation);
@@ -84,8 +89,11 @@ class _CapturePageState extends State<CapturePage> {
   }
 
   Future initCamera(CameraDescription cameraDescription) async {
-    _cameraController =
-        CameraController(cameraDescription, ResolutionPreset.high, enableAudio: false);
+    _cameraController = CameraController(
+      cameraDescription,
+      ResolutionPreset.high,
+      enableAudio: false,
+    );
     try {
       await _cameraController.initialize().then((_) {
         if (!mounted) return;
@@ -99,133 +107,131 @@ class _CapturePageState extends State<CapturePage> {
 
   @override
   Widget build(BuildContext context) {
+    if (widget.cameras?.isEmpty ?? true) {
+      return Scaffold(
+        appBar: AppBar(),
+        body: const Center(
+          child: Text('No camera found for this device'),
+        ),
+      );
+    }
     var height = MediaQuery.of(context).size.height * 0.12;
     var cartIcon = IconButton(
-      onPressed: () {
-      },
+      onPressed: () {},
       iconSize: 30,
       padding: EdgeInsets.zero,
       constraints: const BoxConstraints(),
       icon: const Icon(Icons.add_shopping_cart_outlined, color: Colors.white),
     );
     return Stack(
-          children: [
-            cameraPreview(),
-            captureButton(height, context),
-            Positioned(
-                bottom: 0,
-                left: 0,
-                child: Container(
-                  width: MediaQuery.of(context).size.width,
-                  height: height,
-                  decoration: const BoxDecoration(color: Colors.black),
-                  child: Row(crossAxisAlignment: CrossAxisAlignment.center, children: [
-                    switchCameraButton(context),
-                    imageCart(cartIcon),
-                    createSequenceButton(context),
-                  ]),
-                )
+      children: [
+        cameraPreview(),
+        captureButton(height, context),
+        Positioned(
+          bottom: 0,
+          left: 0,
+          child: Container(
+            width: MediaQuery.of(context).size.width,
+            height: height,
+            decoration: const BoxDecoration(color: Colors.black),
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.center,
+              children: [
+                switchCameraButton(context),
+                imageCart(cartIcon),
+                createSequenceButton(context),
+              ],
             ),
-            if(_isProcessing) processingLoader(context)
-          ]
-        );
+          ),
+        ),
+        if (_isProcessing) processingLoader(context)
+      ],
+    );
   }
 
   Expanded switchCameraButton(BuildContext context) {
     return Expanded(
-                      child: IconButton(
-                        padding: EdgeInsets.zero,
-                        iconSize: 30,
-                        icon: Icon(
-                            _isRearCameraSelected
-                                ? CupertinoIcons.switch_camera
-                                : CupertinoIcons.switch_camera_solid,
-                            color: Colors.white),
-                        onPressed: () {
-                          setState(
-                                  () => _isRearCameraSelected = !_isRearCameraSelected);
-                          initCamera(widget.cameras![_isRearCameraSelected ? 0 : 1]);
-                        },
-                        tooltip: AppLocalizations.of(context)!.switchCamera
-                      )
-                  );
+      child: IconButton(
+          padding: EdgeInsets.zero,
+          iconSize: 30,
+          icon: Icon(_isRearCameraSelected ? CupertinoIcons.switch_camera : CupertinoIcons.switch_camera_solid,
+              color: Colors.white),
+          onPressed: () {
+            setState(() => _isRearCameraSelected = !_isRearCameraSelected);
+            initCamera(widget.cameras![_isRearCameraSelected ? 0 : 1]);
+          },
+          tooltip: AppLocalizations.of(context)!.switchCamera),
+    );
   }
 
   Expanded createSequenceButton(BuildContext context) {
     return Expanded(
-                      child: IconButton(
-                        padding: EdgeInsets.zero,
-                        iconSize: 30,
-                        icon: const Icon(
-                          Icons.send_outlined,
-                          color: Colors.white
-                        ),
-                        onPressed: goToCollectionCreationPage,
-                        tooltip: AppLocalizations.of(context)!.createSequenceWithPicture_tooltip
-                      )
-                  );
+        child: IconButton(
+            padding: EdgeInsets.zero,
+            iconSize: 30,
+            icon: const Icon(Icons.send_outlined, color: Colors.white),
+            onPressed: goToCollectionCreationPage,
+            tooltip: AppLocalizations.of(context)!.createSequenceWithPicture_tooltip));
   }
 
   Widget imageCart(IconButton cartIcon) {
-    return _imgListCaptured.isNotEmpty ?
-              badges.Badge(
-                    badgeContent: Text('${_imgListCaptured.length}'),
-                    child: cartIcon,
-              ):
-              cartIcon;
+    return _imgListCaptured.isNotEmpty
+        ? badges.Badge(
+            badgeContent: Text('${_imgListCaptured.length}'),
+            child: cartIcon,
+          )
+        : cartIcon;
   }
 
   Positioned captureButton(double height, BuildContext context) {
     return Positioned(
-              bottom: height,
-              left: 0,
-              child: Container(
-                width: MediaQuery.of(context).size.width,
-                height: height,
-                decoration: const BoxDecoration(color: Colors.transparent),
-                child: Row(crossAxisAlignment: CrossAxisAlignment.center, children: [
-                  Expanded(
-                      child: IconButton(
-                        onPressed: takePicture,
-                        iconSize: 100,
-                        padding: EdgeInsets.zero,
-                        constraints: const BoxConstraints(),
-                        icon: const Icon(Icons.circle_outlined, color: Colors.white),
-                        tooltip: AppLocalizations.of(context)!.capture
-                      )),
-                ]),
-              )
-          );
+        bottom: height,
+        left: 0,
+        child: Container(
+          width: MediaQuery.of(context).size.width,
+          height: height,
+          decoration: const BoxDecoration(color: Colors.transparent),
+          child: Row(crossAxisAlignment: CrossAxisAlignment.center, children: [
+            Expanded(
+              child: IconButton(
+                  onPressed: takePicture,
+                  iconSize: 100,
+                  padding: EdgeInsets.zero,
+                  constraints: const BoxConstraints(),
+                  icon: const Icon(Icons.circle_outlined, color: Colors.white),
+                  tooltip: AppLocalizations.of(context)!.capture),
+            ),
+          ]),
+        ));
   }
 
   StatelessWidget cameraPreview() {
     return _cameraController.value.isInitialized
-              ? CameraPreview(_cameraController)
-              : Container(
-                color: Colors.transparent,
-                child: const Center(child: CircularProgressIndicator()
-              )
-    );
+        ? CameraPreview(_cameraController)
+        : Container(
+            color: Colors.transparent,
+            child: const Center(child: CircularProgressIndicator()),
+          );
   }
 
   Positioned processingLoader(BuildContext context) {
     return Positioned(
-        top: 0,
-        bottom: 0,
-        left: 0,
-        right: 0,
-        child: Loader(
-            message: DefaultTextStyle(
-              style: Theme.of(context).textTheme.bodyLarge!,
-              child: Text(
-                AppLocalizations.of(context)!.waitDuringProcessing,
-                style: const TextStyle(
-                  color: Colors.white,
-                ),
-              ),
+      top: 0,
+      bottom: 0,
+      left: 0,
+      right: 0,
+      child: Loader(
+        message: DefaultTextStyle(
+          style: Theme.of(context).textTheme.bodyLarge!,
+          child: Text(
+            AppLocalizations.of(context)!.waitDuringProcessing,
+            style: const TextStyle(
+              color: Colors.white,
             ),
-            shadowBackground: true
-        )
+          ),
+        ),
+        shadowBackground: true,
+      ),
     );
   }
 }

--- a/lib/page/homepage.dart
+++ b/lib/page/homepage.dart
@@ -39,64 +39,57 @@ class _HomePageState extends State<HomePage> {
     if (!await PermissionHelper.isPermissionGranted()) {
       await PermissionHelper.askMissingPermission();
     }
-    await availableCameras().then((availableCameras) =>
-        context.push(Routes.newSequenceCapture, extra: availableCameras)
+    await availableCameras().then(
+      (availableCameras) => context.push(Routes.newSequenceCapture, extra: availableCameras),
     );
   }
-  
+
   Widget displayBody(isLoading) {
-    if(isLoading)
-      return LoaderIndicatorView();
-    else if(geoVisionCollections == null)
-      return UnkownErrorView();
-    else if(geoVisionCollections!.collections.length != 0)
+    if (isLoading) {
+      return const LoaderIndicatorView();
+    } else if (geoVisionCollections == null) {
+      return const UnknownErrorView();
+    } else if (geoVisionCollections!.collections.isNotEmpty) {
       return CollectionListView(collections: geoVisionCollections!.collections);
-    else
-      return NoElementView();
+    } else {
+      return const NoElementView();
+    }
   }
 
   @override
   Widget build(BuildContext context) {
     return RefreshIndicator(
-        displacement: 250,
-        strokeWidth: 3,
-        triggerMode: RefreshIndicatorTriggerMode.onEdge,
-        onRefresh: () async {
-          setState(() {
-            getCollections();
-          });
-        },
-        child: Scaffold(
-            appBar: PanoramaxAppBar(context: context),
-            body: SingleChildScrollView(
-              child: Stack(
-                children: <Widget>[
-                  Container(
-                      margin: const EdgeInsets.fromLTRB(10, 10, 10, 10),
-                      child: Semantics(
-                        header: true,
-                        child: Text(
-                            AppLocalizations.of(context)!.yourSequence,
-                            style: GoogleFonts.nunito(
-                                fontSize: 25,
-                                fontWeight: FontWeight.w400
-                            )
-                        ),
-                      )
-                  ),
-                  SizedBox(
-                      height: 720,
-                      child: displayBody(isLoading)
-                  )
-                ]
+      displacement: 250,
+      strokeWidth: 3,
+      triggerMode: RefreshIndicatorTriggerMode.onEdge,
+      onRefresh: () async {
+        setState(() {
+          getCollections();
+        });
+      },
+      child: Scaffold(
+        appBar: PanoramaxAppBar(context: context),
+        body: Column(
+          children: <Widget>[
+            Container(
+              margin: const EdgeInsets.fromLTRB(10, 10, 10, 10),
+              child: Semantics(
+                header: true,
+                child: Text(AppLocalizations.of(context)!.yourSequence,
+                    style: GoogleFonts.nunito(fontSize: 25, fontWeight: FontWeight.w400)),
               ),
             ),
-            floatingActionButton: FloatingActionButton(
-              onPressed: _createCollection,
-              tooltip: AppLocalizations.of(context)!.createSequence_tooltip,
-              child: const Icon(Icons.add),
-            )
+            Expanded(
+              child: displayBody(isLoading),
+            ),
+          ],
         ),
+        floatingActionButton: FloatingActionButton(
+          onPressed: _createCollection,
+          tooltip: AppLocalizations.of(context)!.createSequence_tooltip,
+          child: const Icon(Icons.add),
+        ),
+      ),
     );
   }
 }
@@ -113,13 +106,10 @@ class CollectionListView extends StatelessWidget {
   Widget build(BuildContext context) {
     return ListView.builder(
       itemCount: collections.length,
-      shrinkWrap: true,
-      physics: BouncingScrollPhysics(
-          parent: AlwaysScrollableScrollPhysics()
-      ),
+      physics: const BouncingScrollPhysics(parent: AlwaysScrollableScrollPhysics()),
       itemBuilder: (BuildContext context, int index) {
         return CollectionPreview(collections[index]);
-      }
+      },
     );
   }
 }
@@ -132,14 +122,14 @@ class LoaderIndicatorView extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Row(
-        mainAxisAlignment: MainAxisAlignment.center,
-        children: [
-          Center(
-            child: Loader(
-              message: Text(AppLocalizations.of(context)!.loading),
-            ),
-          )
-        ]
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        Center(
+          child: Loader(
+            message: Text(AppLocalizations.of(context)!.loading),
+          ),
+        ),
+      ],
     );
   }
 }
@@ -157,20 +147,16 @@ class NoElementView extends StatelessWidget {
         Center(
           child: Text(
             AppLocalizations.of(context)!.emptyError,
-            style: GoogleFonts.nunito(
-                fontSize: 18,
-                color: Colors.grey,
-                fontWeight: FontWeight.w400
-            )
-          )
+            style: GoogleFonts.nunito(fontSize: 18, color: Colors.grey, fontWeight: FontWeight.w400),
+          ),
         )
-      ]
+      ],
     );
   }
 }
 
-class UnkownErrorView extends StatelessWidget {
-  const UnkownErrorView({
+class UnknownErrorView extends StatelessWidget {
+  const UnknownErrorView({
     super.key,
   });
 
@@ -182,14 +168,10 @@ class UnkownErrorView extends StatelessWidget {
         Center(
           child: Text(
             AppLocalizations.of(context)!.unknownError,
-            style: GoogleFonts.nunito(
-              fontSize: 20,
-              color: Colors.red,
-              fontWeight: FontWeight.w400
-            )
-          )
+            style: GoogleFonts.nunito(fontSize: 20, color: Colors.red, fontWeight: FontWeight.w400),
+          ),
         )
-      ]
+      ],
     );
   }
 }


### PR DESCRIPTION
On some devices (desktop, web, iOS emulators) camera can be unavailable, and the app display a verbose error. 
With this feature, we display an error for the User, and the way to return the Home page (thanks to the Scaffold).

Plus, I fix the scroll on Home page (by removing the hard-coded `SizedBox`), to allow scrolling on every devices, no matter the size of it.
And I apply some lint issues (`const`, brackets, misspelling word).


I can split this MR is multiple if you consider this one is too big, or if you think some changes are not mandatory. 
Please let me know if you want I add/remove some stuff here ;)  