### PR TITLE
Fix warning in Github Actions

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: subosito/flutter-action@v2
         with:
             channel: 'stable'
-      - uses: actions/setup-java@v3
+      - uses: actions/setup-java@v4
         with:
             java-version: '17'
             distribution: 'adopt'


### PR DESCRIPTION
This PR fixes warning in workflows because we using setup-java v3 which use a deprecated version of node js

- https://github.com/nobelization/panoramax-mobile-app/actions/runs/10460052688
- https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/
- [releases notes](https://github.com/actions/setup-java/releases/tag/v4.0.0)