### PR TITLE
fix: add a date when an user take a picture

### DIFF
--- a/lib/page/capture_page.dart
+++ b/lib/page/capture_page.dart
@@ -214,6 +214,11 @@ class _CapturePageState extends State<CapturePage> with WidgetsBindingObserver {
       await exif.setLatLong(
           currentLocation.latitude, currentLocation.longitude);
       await exif.setAltitude(currentLocation.altitude);
+
+      DateTime now = DateTime.now().toUtc();
+      String formattedDate = DateFormat('yyyy:MM:dd HH:mm:ss').format(now);
+
+      exif.setAttribute('GPSDateTime', formattedDate);
       await exif.saveAttributes();
     }
   }


### PR DESCRIPTION
The date is forcibly added to the EXIF of the photo in case it is missing or incorrectly formatted.