### PR TITLE
chore: migrate build config to app module

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -39,6 +39,9 @@ android {
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
     }
+    buildFeatures {
+        buildConfig = true
+    }
 
     defaultConfig {
         applicationId "com.panoramax.app"

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,6 +1,5 @@
 org.gradle.jvmargs=-Xmx4G
 android.useAndroidX=true
 android.enableJetifier=true
-android.defaults.buildfeatures.buildconfig=true
 android.nonTransitiveRClass=false
 android.nonFinalResIds=false


### PR DESCRIPTION
With gradle 8.0, buildConfig properties in properties file is deprecated. We need to specify buildConfig properties foreach app module -> https://stackoverflow.com/questions/74634321/fixing-the-build-type-contains-custom-buildconfig-fields-but-the-feature-is-di